### PR TITLE
Set up a logger options API instance.

### DIFF
--- a/src/boot/logger.ts
+++ b/src/boot/logger.ts
@@ -1,3 +1,4 @@
+import { boot } from 'quasar/wrappers';
 import winston from 'winston';
 import 'setimmediate';
 
@@ -14,7 +15,7 @@ const logger = winston.createLogger({
 			level: 'error',
 			host: 'localhost',
 			port: 8080,
-			path: '/webwork3/api/client-logs',
+			path: `${process.env.VUE_ROUTER_BASE ?? ''}api/client-logs`,
 			handleExceptions: true
 		})
 	]
@@ -31,4 +32,9 @@ if (process.env.NODE_ENV !== 'production') {
 	}));
 }
 
-export default logger;
+export default boot(({ app }) => {
+	// For use inside Vue files (Options API) through this.$logger
+	app.config.globalProperties.$logger = logger;
+});
+
+export { logger };


### PR DESCRIPTION
Modify the client side logger set up a bit to create a logger options API instance.  This is what I meant about setting up the globalProperties instance.

Also, use the VUE_ROUTER_BASE for the base path of the http transport.