### PR TITLE
Add the logger to the boot configuration in quasar.conf.js.

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -18,7 +18,8 @@ module.exports = configure(function (ctx) {
 
 		boot: [
 			'axios',
-			'i18n'
+			'i18n',
+			'logger'
 		],
 
 		css: [


### PR DESCRIPTION
I forgot this essential step to make the logger really be instantiated at initialization.