### PR TITLE
some more cleanup to drdrew42/userset-cleanup

### DIFF
--- a/lib/DB/Schema/Result/Attempt.pm
+++ b/lib/DB/Schema/Result/Attempt.pm
@@ -4,7 +4,7 @@ use DBIx::Class::Core;
 use strict;
 use warnings;
 
-use base qw(DBIx::Class::Core DB::Validation);
+use base qw/DBIx::Class::Core DB::Validation/;
 
 =head1 DESCRIPTION
 

--- a/lib/DB/Schema/Result/CourseUser.pm
+++ b/lib/DB/Schema/Result/CourseUser.pm
@@ -134,8 +134,8 @@ __PACKAGE__->add_columns(
 	}
 );
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'course_user_params') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'course_user_params') {
 		return {
 			comment        => q{.*},
 			useMathQuill   => 'bool',
@@ -147,11 +147,11 @@ sub valid_fields ($self, %args) {
 	}
 }
 
-sub required ($self, %args) {
+sub required ($self, $field_name) {
 	return {};
 }
 
-sub additional_validation ($self, %args) {
+sub additional_validation ($self, $field_name) {
 	return 1;
 }
 

--- a/lib/DB/Schema/Result/ProblemSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet.pm
@@ -6,7 +6,7 @@ no warnings qw/experimental::signatures/;
 
 use Mojo::JSON qw/true false/;
 use DB::Utils qw/updateAllFields/;
-use base qw(DBIx::Class::Core);
+use base qw/DBIx::Class::Core/;
 
 =head1 DESCRIPTION
 
@@ -173,7 +173,7 @@ sub validateOverrides ($set, $updates) {
 		$set->_stripUnchanged($updates, $field_name);
 		$set->set_inflated_column(
 			"$field_name" => updateAllFields($set->get_inflated_column($field_name), $updates->{$field_name}));
-		$set->validate(field_name => $field_name);
+		$set->validate($field_name);
 	}
 	$set->discard_changes;
 	return;
@@ -189,7 +189,7 @@ unchanged from the problem_set
 =cut
 
 sub _stripUnchanged ($set, $updates, $field_name) {
-	foreach (keys %{ $set->valid_fields(field_name => $field_name) }) {
+	foreach (keys %{ $set->valid_fields($field_name) }) {
 		next unless exists($updates->{$field_name}{$_});
 		my $defined   = defined($updates->{$field_name}{$_}) ? 1 : 0;
 		my $is_truthy = $updates->{$field_name}{$_}          ? 1 : 0;

--- a/lib/DB/Schema/Result/ProblemSet/HWSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet/HWSet.pm
@@ -5,7 +5,7 @@ use warnings;
 use feature 'signatures';
 no warnings qw/experimental::signatures/;
 
-use base qw(DB::Schema::Result::ProblemSet DB::Validation);
+use base qw/DB::Schema::Result::ProblemSet DB::Validation/;
 
 =head1 DESCRIPTION
 
@@ -23,8 +23,8 @@ subroutine that returns a hash of the validation for both set_dates and set_para
 
 =cut
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return {
 			open                   => q{\d+},
 			reduced_scoring        => q{\d+},
@@ -32,7 +32,7 @@ sub valid_fields ($self, %args) {
 			answer                 => q{\d+},
 			enable_reduced_scoring => 'bool'
 		};
-	} elsif ($args{field_name} eq 'set_params') {
+	} elsif ($field_name eq 'set_params') {
 		return {
 			hide_hint       => 'bool',
 			hardcopy_header => q{.*},
@@ -50,8 +50,8 @@ subroutine that checks any additional validation
 
 =cut
 
-sub additional_validation ($self, %args) {
-	return 1 if ($args{field_name} ne 'set_dates');
+sub additional_validation ($self, $field_name) {
+	return 1 if ($field_name ne 'set_dates');
 
 	my $dates = $self->get_inflated_column('set_dates');
 
@@ -74,8 +74,8 @@ subroutine that returns the array for required set_dates or set_params (none)
 
 =cut
 
-sub required ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub required ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return { '_ALL_' => [ 'open', 'due', 'answer' ] };
 	} else {
 		return {};

--- a/lib/DB/Schema/Result/ProblemSet/Quiz.pm
+++ b/lib/DB/Schema/Result/ProblemSet/Quiz.pm
@@ -23,14 +23,14 @@ subroutine that returns a hash of the validation for both set_dates and set_para
 
 =cut
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return {
 			open   => q{\d+},
 			due    => q{\d+},
 			answer => q{\d+}
 		};
-	} elsif ($args{field_name} eq 'set_params') {
+	} elsif ($field_name eq 'set_params') {
 		return {
 			timed                 => 'bool',
 			quiz_duration         => q{\d+},
@@ -58,8 +58,8 @@ subroutine that checks any additional validation
 
 =cut
 
-sub additional_validation ($self, %args) {
-	return 1 if ($args{field_name} ne 'set_dates');
+sub additional_validation ($self, $field_name) {
+	return 1 if ($field_name ne 'set_dates');
 
 	my $dates = $self->get_inflated_column('set_dates');
 	DB::Exception::ImproperDateOrder->throw(message => 'The dates are not in order')
@@ -74,8 +74,8 @@ subroutine that returns the array for required set_dates or set_params (none)
 
 =cut
 
-sub required ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub required ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return { '_ALL_' => [ 'open', 'due', 'answer' ] };
 	} else {
 		return {};

--- a/lib/DB/Schema/Result/ProblemSet/ReviewSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet/ReviewSet.pm
@@ -5,7 +5,7 @@ use warnings;
 use feature 'signatures';
 no warnings qw/experimental::signatures/;
 
-use base qw(DB::Schema::Result::ProblemSet DB::Validation);
+use base qw/DB::Schema::Result::ProblemSet DB::Validation/;
 
 =head1 DESCRIPTION
 
@@ -23,13 +23,13 @@ subroutine that returns a hash of the validation for both set_dates and set_para
 
 =cut
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return {
 			open   => q{\d+},
 			closed => q{\d+},
 		};
-	} elsif ($args{field_name} eq 'set_params') {
+	} elsif ($field_name eq 'set_params') {
 		return { can_retake => 'bool', };
 	} else {
 		return {};
@@ -42,8 +42,8 @@ subroutine that checks any additional validation
 
 =cut
 
-sub additional_validation ($self, %args) {
-	return 1 if ($args{field_name} ne 'set_dates');
+sub additional_validation ($self, $field_name) {
+	return 1 if ($field_name ne 'set_dates');
 
 	my $dates = $self->get_inflated_column('set_dates');
 	DB::Exception::ImproperDateOrder->throw(message => 'The dates are not in order')
@@ -58,8 +58,8 @@ subroutine that returns the array for required set_dates or set_params (none)
 
 =cut
 
-sub required ($self, %args) {
-	if ($args{field_name} eq 'set_dates') {
+sub required ($self, $field_name) {
+	if ($field_name eq 'set_dates') {
 		return { '_ALL_' => [ 'open', 'closed' ] };
 	} else {
 		return {};

--- a/lib/DB/Schema/Result/SetProblem.pm
+++ b/lib/DB/Schema/Result/SetProblem.pm
@@ -61,8 +61,8 @@ Note: a problem should have only one of a library_id, problem_path or problem_po
 
 =cut
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'problem_params') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'problem_params') {
 		return {
 			weight          => q{^[+]?([0-9]+(?:[\.][0-9]*)?|\.[0-9]+)$},    # positive integers or decimals
 			library_id      => q{\d+},
@@ -75,18 +75,18 @@ sub valid_fields ($self, %args) {
 	}
 }
 
-sub required ($self, %args) {
+sub required ($self, $field_name) {
 	# Although the following is desirable eventually.
 	# return { '_ALL_' => [ 'weight', { '_ONE_OF_' => [ 'library_id', 'file_path', 'problem_pool_id' ] } ] };
 	# currently, don't have any restrictions on the params.
-	if ($args{field_name} eq 'problem_params') {
+	if ($field_name eq 'problem_params') {
 		return { '_ALL_' => [ 'weight', { '_AT_LEAST_ONE_OF_' => [ 'library_id', 'file_path', 'problem_pool_id' ] } ] };
 	} else {
 		return {};
 	}
 }
 
-sub additional_validation ($self, %args) {
+sub additional_validation ($self, $field_name) {
 	return 1;
 }
 

--- a/lib/DB/Schema/Result/UserProblem.pm
+++ b/lib/DB/Schema/Result/UserProblem.pm
@@ -6,7 +6,7 @@ use warnings;
 use feature 'signatures';
 no warnings qw/experimental::signatures/;
 
-use base qw(DBIx::Class::Core DB::Validation);
+use base qw/DBIx::Class::Core DB::Validation/;
 
 # This is the table that stores problems for a given Problem Set.
 # Note: we probably also need to store the problem info if it changes.
@@ -56,8 +56,8 @@ __PACKAGE__->add_columns(
 	}
 );
 
-sub valid_fields ($self, %args) {
-	if ($args{field_name} eq 'problem_params') {
+sub valid_fields ($self, $field_name) {
+	if ($field_name eq 'problem_params') {
 
 		return {
 			# positive integers or decimals
@@ -81,11 +81,11 @@ sub valid_fields ($self, %args) {
 	}
 }
 
-sub required ($self, %args) {
+sub required ($self, $field_name) {
 	return {};
 }
 
-sub additional_validation ($self, %args) {
+sub additional_validation ($self, $field_name) {
 	return 1;
 }
 

--- a/lib/DB/Schema/Result/UserSet.pm
+++ b/lib/DB/Schema/Result/UserSet.pm
@@ -116,14 +116,6 @@ __PACKAGE__->belongs_to(
 __PACKAGE__->belongs_to(problem_set => 'DB::Schema::Result::ProblemSet', 'set_id');
 __PACKAGE__->has_many(user_problems => 'DB::Schema::Result::UserProblem', 'user_set_id');
 
-# See https://metacpan.org/dist/DBIx-Class/view/lib/DBIx/Class/Manual/Cookbook.pod
-# under: Dynamic-Sub-classing-DBIx::Class-proxy-classes
-sub inflate_result ($self, @args) {
-	my $ret = $self->next::method(@args);
-	# bless into subclass based on relation to problem_set
-	return bless $ret, (ref($ret->problem_set) =~ s/:ProblemSet:/:UserSet:/r);
-}
-
 sub set_type ($self) {
 	my %set_type_rev = reverse %{$DB::Schema::ResultSet::ProblemSet::SET_TYPES};
 	return $set_type_rev{ $self->problem_set->type };

--- a/lib/DB/Schema/Result/UserSet/HWSet.pm
+++ b/lib/DB/Schema/Result/UserSet/HWSet.pm
@@ -8,16 +8,4 @@ no warnings qw/experimental::signatures/;
 use base qw/DB::Schema::Result::UserSet/;
 use DB::Schema::Result::ProblemSet::HWSet;
 
-sub valid_fields ($self, %args) {
-	return DB::Schema::Result::ProblemSet::HWSet::valid_fields($self, %args);
-}
-
-sub required ($self, %args) {
-	return {};
-}
-
-sub additional_validation ($self, %args) {
-	return DB::Schema::Result::ProblemSet::HWSet::additional_validation($self, %args);
-}
-
 1;

--- a/lib/DB/Schema/Result/UserSet/Quiz.pm
+++ b/lib/DB/Schema/Result/UserSet/Quiz.pm
@@ -8,16 +8,4 @@ no warnings qw/experimental::signatures/;
 use base qw/DB::Schema::Result::UserSet/;
 use DB::Schema::Result::ProblemSet::Quiz;
 
-sub valid_fields ($self, %args) {
-	return DB::Schema::Result::ProblemSet::Quiz::valid_fields($self, %args);
-}
-
-sub required ($self, %args) {
-	return {};
-}
-
-sub additional_validation ($self, %args) {
-	return DB::Schema::Result::ProblemSet::Quiz::additional_validation($self, %args);
-}
-
 1;

--- a/lib/DB/Schema/Result/UserSet/ReviewSet.pm
+++ b/lib/DB/Schema/Result/UserSet/ReviewSet.pm
@@ -8,16 +8,4 @@ no warnings qw/experimental::signatures/;
 use base qw/DB::Schema::Result::UserSet/;
 use DB::Schema::Result::ProblemSet::ReviewSet;
 
-sub valid_fields ($self, %args) {
-	return DB::Schema::Result::ProblemSet::ReviewSet::valid_fields($self, %args);
-}
-
-sub required ($self, %args) {
-	return {};
-}
-
-sub additional_validation ($self, %args) {
-	return DB::Schema::Result::ProblemSet::ReviewSet::additional_validation($self, %args);
-}
-
 1;

--- a/lib/DB/Schema/ResultSet/ProblemSet.pm
+++ b/lib/DB/Schema/ResultSet/ProblemSet.pm
@@ -357,8 +357,8 @@ sub addProblemSet {
 
 	# Check that fields/dates/parameters are valid
 	my $set_obj = $self->new($set_params);
-	$set_obj->validate(field_name => 'set_dates');
-	$set_obj->validate(field_name => 'set_params');
+	$set_obj->validate('set_dates');
+	$set_obj->validate('set_params');
 
 	my $new_set = $course->add_to_problem_sets($set_params);
 
@@ -470,8 +470,8 @@ sub updateProblemSet ($self, %args) {
 	my $set_obj = $self->new($params2);
 
 	# Check the parameters are valid.
-	$set_obj->validate(field_name => 'set_dates')  if $set_obj->set_dates;
-	$set_obj->validate(field_name => 'set_params') if $set_obj->set_params;
+	$set_obj->validate('set_dates')  if $set_obj->set_dates;
+	$set_obj->validate('set_params') if $set_obj->set_params;
 	my $updated_set = $problem_set->update({ $set_obj->get_inflated_columns });
 	return $updated_set if $args{as_result_set};
 	my $set = { $updated_set->get_inflated_columns, set_type => $updated_set->set_type };

--- a/lib/DB/Schema/ResultSet/SetProblem.pm
+++ b/lib/DB/Schema/ResultSet/SetProblem.pm
@@ -255,7 +255,7 @@ sub checkProblemParams ($self, $params) {
 		unless defined $params->{problem_number} && $params->{problem_number} =~ /^\d+$/;
 
 	my $problem_to_add = $self->new($params);
-	$problem_to_add->validate(field_name => 'problem_params');
+	$problem_to_add->validate('problem_params');
 	return 1;
 }
 

--- a/lib/DB/Schema/ResultSet/User.pm
+++ b/lib/DB/Schema/ResultSet/User.pm
@@ -416,7 +416,7 @@ sub addCourseUser ($self, %args) {
 
 	# check for valid fields and parameters
 	my $updated_user = $self->rs('CourseUser')->new($params);
-	$updated_user->validate(field_name => 'course_user_params');
+	$updated_user->validate('course_user_params');
 
 	my $user   = $self->getGlobalUser(info => getUserInfo($args{info}), as_result_set => 1);
 	my $course = $self->rs('Course')->getCourse(info => getCourseInfo($args{info}), as_result_set => 1);
@@ -495,7 +495,7 @@ sub updateCourseUser ($self, %args) {
 	}
 
 	my $params_to_check = $self->rs('CourseUser')->new($params);
-	$params_to_check->validate(field_name => 'course_user_params');
+	$params_to_check->validate('course_user_params');
 
 	my $user_to_return = $course_user->update($params);
 

--- a/lib/DB/Schema/ResultSet/UserProblem.pm
+++ b/lib/DB/Schema/ResultSet/UserProblem.pm
@@ -549,7 +549,7 @@ sub checkParams ($self, $params) {
 
 	# Check that other fields/params are correct.
 	my $prob_to_check = $self->new($params);
-	return $prob_to_check->validate(field_name => 'problem_params');
+	return $prob_to_check->validate('problem_params');
 }
 
 sub _mergeUserProblem ($user_problem) {

--- a/lib/DB/Validation.pm
+++ b/lib/DB/Validation.pm
@@ -24,20 +24,20 @@ required fields, validates the parameters and running any additional validation.
 
 =cut
 
-sub validate ($self, %args) {
-	$self->checkForValidFields(%args);
-	$self->checkRequiredFields(%args);
-	$self->validateParams(%args);
-	$self->additional_validation(%args);
+sub validate ($self, $field_name) {
+	$self->checkForValidFields($field_name);
+	$self->checkRequiredFields($field_name);
+	$self->validateParams($field_name);
+	$self->additional_validation($field_name);
 	return 1;
 }
 
 # Check if the hash has the correct fields.
-sub checkForValidFields ($self, %args) {
-	my $params = $self->get_inflated_column($args{field_name});
+sub checkForValidFields ($self, $field_name) {
+	my $params = $self->get_inflated_column($field_name);
 	return 1 unless defined($params);
 
-	my $valid_fields = $self->valid_fields(%args);
+	my $valid_fields = $self->valid_fields($field_name);
 	my @valid_fields = keys %$valid_fields;
 	my @fields       = keys %$params;
 	my @inter        = intersect(@fields, @valid_fields);
@@ -50,9 +50,9 @@ sub checkForValidFields ($self, %args) {
 	return 1;
 }
 
-sub validateParams ($self, %args) {
-	my $params       = $self->get_inflated_column($args{field_name});
-	my $valid_fields = ref($self)->valid_fields(%args);
+sub validateParams ($self, $field_name) {
+	my $params       = $self->get_inflated_column($field_name);
+	my $valid_fields = ref($self)->valid_fields($field_name);
 
 	# if it doesn't exist, it is valid
 	return 1 unless defined $params;
@@ -67,15 +67,15 @@ sub validateParams ($self, %args) {
 	return 1;
 }
 
-sub checkRequiredFields ($self, %args) {
-	my $required_fields = ref($self)->required(%args);
+sub checkRequiredFields ($self, $field_name) {
+	my $required_fields = ref($self)->required($field_name);
 	# Depending on the data type of the $required_params, check different things.
 	DB::Exception::ParamFormatIncorrect->throw(
 		message => 'The structure of the return type of ' . ref($self) . '::required must be a hashref.')
 		unless reftype($required_fields) eq 'HASH';
 
 	for my $key (keys %$required_fields) {
-		last unless $self->_check_params($args{field_name}, $key, $required_fields->{$key});
+		last unless $self->_check_params($field_name, $key, $required_fields->{$key});
 	}
 	return 1;
 }

--- a/lib/WeBWorK3/Utils/Settings.pm
+++ b/lib/WeBWorK3/Utils/Settings.pm
@@ -8,17 +8,17 @@ no warnings qw/experimental::signatures/;
 use YAML::XS qw/LoadFile/;
 
 require Exporter;
-use base qw(Exporter);
+use base qw/Exporter/;
 our @EXPORT_OK = qw/checkSettings getDefaultCourseSettings getDefaultCourseValues
 	mergeCourseSettings validateSettingsConfFile validateCourseSettings
 	validateSingleCourseSetting validateSettingConfig
 	isInteger isTimeString isTimeDuration isDecimal/;
 
-use Exception::Class qw(
+use Exception::Class qw/
 	DB::Exception::UndefinedCourseField
 	DB::Exception::InvalidCourseField
 	DB::Exception::InvalidCourseFieldType
-);
+/;
 
 use WeBWorK3;
 

--- a/t/db/001_courses.t
+++ b/t/db/001_courses.t
@@ -14,7 +14,7 @@ BEGIN {
 use lib "$main::ww3_dir/lib";
 use lib "$main::ww3_dir/t/lib";
 
-use List::MoreUtils qw(uniq);
+use List::MoreUtils qw/uniq/;
 
 use Test::More;
 use Test::Exception;

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -10,7 +10,7 @@ use DateTime::Format::Strptime;
 use Mojo::JSON qw/true false/;
 
 require Exporter;
-use base qw(Exporter);
+use base qw/Exporter/;
 our @EXPORT_OK = qw/buildHash loadCSV removeIDs cleanUndef filterBySetType loadSchema/;
 
 my $strp_datetime = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');


### PR DESCRIPTION
This 
- removes some code related to subclasses of `UserSet`s, which aren't needed any more.
- removes the `%args` in the subs in `Validation`, since there is only the field_name argument for these.
- a few more `qw( )` to `qw/ /` for consistency.  